### PR TITLE
Demonstrate issue with defining properties that are interfaces

### DIFF
--- a/src/main/kotlin/com/github/markoresic/footballvotingdemo/config/ApplicationConfig.kt
+++ b/src/main/kotlin/com/github/markoresic/footballvotingdemo/config/ApplicationConfig.kt
@@ -10,7 +10,8 @@ import org.springframework.security.core.userdetails.UsernameNotFoundException
 @Configuration
 class ApplicationConfig {
 
-    lateinit var repository: UserRepository
+    //Property must be initialized or be abstract
+    val repository: UserRepository
 
     val userDetailsService = object : UserDetailsService {
         override fun loadUserByUsername(username: String): UserDetails {

--- a/src/main/kotlin/com/github/markoresic/footballvotingdemo/config/ApplicationConfig.kt
+++ b/src/main/kotlin/com/github/markoresic/footballvotingdemo/config/ApplicationConfig.kt
@@ -1,21 +1,20 @@
 package com.github.markoresic.footballvotingdemo.config
 
 import com.github.markoresic.footballvotingdemo.repository.UserRepository
+import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
-import org.springframework.security.core.userdetails.UserDetails
 import org.springframework.security.core.userdetails.UserDetailsService
 import org.springframework.security.core.userdetails.UsernameNotFoundException
 
 
 @Configuration
-class ApplicationConfig {
+class ApplicationConfig(val userRepository: UserRepository) {
 
-    //Property must be initialized or be abstract
-    val repository: UserRepository
-
-    val userDetailsService = object : UserDetailsService {
-        override fun loadUserByUsername(username: String): UserDetails {
-            return repository.findByEmail(username) ?: throw UsernameNotFoundException("User not found")
+    @Bean
+    fun userDetailsService(): UserDetailsService {
+        return UserDetailsService { email: String ->
+            userRepository.findByEmail(email).orElseThrow { UsernameNotFoundException("User not found") }
         }
     }
+
 }

--- a/src/main/kotlin/com/github/markoresic/footballvotingdemo/config/JwtAuthenticationFilter.kt
+++ b/src/main/kotlin/com/github/markoresic/footballvotingdemo/config/JwtAuthenticationFilter.kt
@@ -13,8 +13,9 @@ import org.springframework.web.filter.OncePerRequestFilter
 @Component
 class JwtAuthenticationFilter : OncePerRequestFilter() {
 
-    lateinit var jwtService: JwtService
-    lateinit var userDetailsService: UserDetailsService
+    val jwtService: JwtService = JwtService()
+    //Property must be initialized or be abstract
+    val userDetailsService: UserDetailsService
 
     override fun doFilterInternal(
         @NonNull request: HttpServletRequest,

--- a/src/main/kotlin/com/github/markoresic/footballvotingdemo/config/JwtAuthenticationFilter.kt
+++ b/src/main/kotlin/com/github/markoresic/footballvotingdemo/config/JwtAuthenticationFilter.kt
@@ -11,20 +11,18 @@ import org.springframework.web.filter.OncePerRequestFilter
 
 
 @Component
-class JwtAuthenticationFilter : OncePerRequestFilter() {
+class JwtAuthenticationFilter(private val userDetailsService: UserDetailsService) : OncePerRequestFilter() {
 
     val jwtService: JwtService = JwtService()
-    //Property must be initialized or be abstract
-    val userDetailsService: UserDetailsService
 
     override fun doFilterInternal(
         @NonNull request: HttpServletRequest,
         @NonNull response: HttpServletResponse,
-        @NonNull filterChain: FilterChain
+        @NonNull filterChain: FilterChain,
     ) {
         val authHeader = request.getHeader("Authorization")
         val userEmail: String
-        if (authHeader == null ||!authHeader.startsWith("Bearer ")) {
+        if (authHeader == null || !authHeader.startsWith("Bearer ")) {
             filterChain.doFilter(request, response)
             return
         }

--- a/src/main/kotlin/com/github/markoresic/footballvotingdemo/config/JwtService.kt
+++ b/src/main/kotlin/com/github/markoresic/footballvotingdemo/config/JwtService.kt
@@ -12,7 +12,7 @@ import javax.crypto.SecretKey
 
 class JwtService {
     @Value("\${application.security.jwt.secret-key}")
-    private val secretKey: String? = null
+    private val secretKey: String = ""
     @Value("\${application.security.jwt.expiration}")
     private val jwtExpiration: Long = 0
     @Value("\${application.security.jwt.refresh-token.expiration}")

--- a/src/main/kotlin/com/github/markoresic/footballvotingdemo/repository/UserRepository.kt
+++ b/src/main/kotlin/com/github/markoresic/footballvotingdemo/repository/UserRepository.kt
@@ -2,7 +2,8 @@ package com.github.markoresic.footballvotingdemo.repository
 
 import com.github.markoresic.footballvotingdemo.model.user.User
 import org.springframework.data.mongodb.repository.MongoRepository
+import java.util.*
 
 interface UserRepository : MongoRepository<User, Int> {
-    fun findByEmail(email: String): User?
+    fun findByEmail(email: String): Optional<User>
 }


### PR DESCRIPTION
How is it possible to use the MongoRepository interface's methods without using any implementation of the interface?

How is it possible to not have to initialize val properties that are of some interface type, like for example, UserDetailsService or UserRepository?

Why can't my project allow these behaviours like some can, for example: https://github.com/titus58/youtube-tutorials/tree/main/bootmongo